### PR TITLE
Fix failing manager build due to missing pip3 dependency

### DIFF
--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -5,8 +5,10 @@ WORKDIR /app
 COPY ./manager/requirements.txt /app
 
 # Copy the current directory contents into the container at /app
-RUN apk update && apk add build-base python3 python3-dev
+RUN apk update && apk add build-base python3 python3-dev curl
 
+# Install pip
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3
 
 # Install any needed packages specified in requirements.txt
 RUN python3 -m pip install --trusted-host pypi.python.org -r requirements.txt


### PR DESCRIPTION
## Description

Fixes #91 
Adds [`get-pip.py`](https://bootstrap.pypa.io/get-pip.py) as a dependency

## Checklist

- [x] [Linked PR to corresponding issue in this repo](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
- [x] Manually tested locally
- [x] ~~Additional issue created in [docs repo](https://github.com/architus/docs.archit.us/issues) (if necessary)~~
