### PR TITLE
Feature/improved purge

### DIFF
--- a/shard/src/ext/purge_command.py
+++ b/shard/src/ext/purge_command.py
@@ -40,7 +40,7 @@ async def purge(ctx):
 @purge.command()
 async def id(ctx, mid, inclusive=False):
     """
-    Purge a channel of a user's messages
+    Purge a channel of messages until a specific message is reached
 
     Usage: {prefix}purge id {message id} [true]
     Purges all messages sent after the message corresponding to the
@@ -116,7 +116,7 @@ async def id(ctx, mid, inclusive=False):
 @purge.command()
 async def time(ctx, time_window):
     """
-    Purge a channel of a user's messages
+    Purge a channel of messages sent in the past X amount of time
 
     Usage: {prefix}purge time {XXm|XXs}
 

--- a/shard/src/ext/purge_command.py
+++ b/shard/src/ext/purge_command.py
@@ -34,11 +34,6 @@ async def purge(ctx):
     from the target message's author in the channel will be deleted depending on the
     timing of when the original message was deleted.
     '''
-    settings = ctx.bot.settings[ctx.guild]
-    if ctx.author.id not in settings.admins_ids:
-        await ctx.send("You do not have permissions to purge messaages")
-        return
-
     if ctx.invoked_subcommand is None:
         await ctx.send("Need to use command with id or time parameter")
         return
@@ -73,6 +68,11 @@ async def id(ctx, mid, inclusive=False):
         message_id = int(mid)
     except ValueError:
         await ctx.send("Message ID has an invalid format")
+        return
+
+    settings = ctx.bot.settings[ctx.guild]
+    if ctx.author.id not in settings.admins_ids:
+        await ctx.send("You do not have permissions to purge messaages")
         return
 
     try:
@@ -141,6 +141,11 @@ async def time(ctx, time_window):
         await ctx.send("Time value formatted improperly")
         return
 
+    settings = ctx.bot.settings[ctx.guild]
+    if ctx.author.id not in settings.admins_ids:
+        await ctx.send("You do not have permissions to purge messaages")
+        return
+
     if time_param[2] == 'm':
         mins = int(time_param[1])
         diff = timedelta(minutes=mins)
@@ -164,7 +169,7 @@ async def time(ctx, time_window):
 
     try:
         async with ctx.channel.typing():
-            for i in rane(0, len(messages_to_delete), 100):
+            for i in range(0, len(messages_to_delete), 100):
                 await ctx.channel.delete_messages(messages_to_delete[i:i + 100])
             await ctx.send(f"Deleted {len(messages_to_delete)} message(s)")
     except discord.Forbidden:

--- a/shard/src/ext/purge_command.py
+++ b/shard/src/ext/purge_command.py
@@ -168,7 +168,7 @@ async def time(ctx, time_window: str, user: discord.Member = None):
     earliest = now - diff
 
     try:
-        if user == None:
+        if user is None:
             messages_to_delete = await ctx.channel.history(limit=MESSAGE_LIMIT, after=earliest).flatten()
         else:
             messages_to_delete = list()

--- a/shard/src/ext/purge_command.py
+++ b/shard/src/ext/purge_command.py
@@ -1,41 +1,189 @@
+import discord
 from discord.ext import commands
 from contextlib import suppress
 
+from datetime import datetime, timedelta
 
-@commands.command()
-async def purge(ctx, *args):
+
+@commands.group()
+async def purge(ctx):
     '''
     Purge a channel of a user's messages
-    optionally include member id, channel, or message limit
+
+    Usage: {prefix}purge id {message id} [true]
+    or: {prefix}purge time {XXm|XXs}
+    The first will purge all messages sent after the message corresponding to the
+    message id of the user who sent that message. If true is passed, then all messages
+    from now until that message will be deleted.
+
+    Only searches the past 500 messages sent in a channel for which to delete.
+    If more than 500 messages have been sent between the given message's id and
+    when this command is run, then all of that user's messages may not get
+    deleted.
+
+    The second usage will delete all messages in the channel in the past number of
+    minutes or seconds.
+
+    NOTE: If the original message is deleted before the bot deletes it, all messages
+    from the target message's author in the channel will be deleted depending on the
+    timing of when the original message was deleted.
     '''
+    # Both subcommands will attempt to use the more efficient channel.delete_messages method
+    # when possible. This operation is only valid when attempting to delete 100
+    # or fewer messages. When this is not possible, the channel.purge method will
+    # be used instead.
+    if ctx.invoked_subcommand is None:
+        await ctx.send("Need to use command with id or time parameter")
+        return
+
+
+@purge.command()
+async def id(ctx, mid, inclusive=False):
+    """
+    Purge a channel of a user's messages
+
+    Usage: {prefix}purge id {message id} [true]
+    Purges all messages sent after the message corresponding to the
+    message id of the user who sent that message. If the optional last
+    parameter is set to true or True then deleted messages will not be
+    limited to just the one author but included all messages in the relevant
+    time period. Any non "true" or "True" value passed in at the end will
+    default to False.
+
+    Only searches the past 500 messages sent in a channel for which to delete.
+    If more than 500 messages have been sent between the given message's id and
+    when this command is run, then all of that user's messages may not get
+    deleted.
+
+    NOTE: If the original message is deleted before the bot deletes it, all messages
+    from the target message's author in the channel will be deleted depending on the
+    timing of when the original message was deleted.
+    """
+    message_id = None
+    try:
+        message_id = int(mid)
+    except ValueError:
+        await ctx.send("Message ID has an invalid format")
+        return
+
     settings = ctx.bot.settings[ctx.guild]
-    user = ctx.bot.user
+    if ctx.author.id not in settings.admins_ids:
+        await ctx.send("You do not have permissions to purge messaages")
+        return
 
-    for arg in args:
-        with suppress(ValueError):
-            user = ctx.guild.get_member(int(arg))
-            if user:
-                break
-    else:
-        user = ctx.bot.user
+    try:
+        original_message = await ctx.channel.fetch_message(message_id)
+    except discord.NotFound:
+        await ctx.send("Original message has already been deleted. "
+                       "Try again with different message.")
+        return
+    except discord.Forbidden:
+        await ctx.send("Architus does not have permission to read message history")
+        return
+    except discord.HTTPException:
+        await ctx.send("Failed to reach discord servers. Try again in a bit")
+        return
+    except Exception:
+        await ctx.send("Something went wrong. :(")
+        return
 
-    for arg in args:
-        with suppress(ValueError):
-            if int(arg) < 100000:
-                count = int(arg)
-    else:
-        count = 100
+    messages_to_delete = []
+    async for m in ctx.channel.history(limit=500):
+        if inclusive or m.author == original_message.author:
+            messages_to_delete.append(m)
+        if m.id == original_message.id:
+            break
 
-    channel = ctx.channel
-    if ctx.message.channel_mentions:
-        channel = ctx.message.channel_mentions[0]
-
-    async with ctx.channel.typing():
-        if (ctx.author.id in settings.admins_ids):
-            deleted = await channel.purge(limit=count, check=lambda m: m.author == user)
-            await ctx.send('Deleted {} message(s)'.format(len(deleted)))
+    try:
+        if len(messages_to_delete) <= 100:
+            async with ctx.channel.typing():
+                await ctx.channel.delete_messages(messages_to_delete)
+                await ctx.send(f"Deleted {len(messages_to_delete)} message(s)")
         else:
-            await ctx.send(f'lul {ctx.author.mention}')
+            ids = list(map(lambda m: m.id, messages_to_delete))
+            async with ctx.channel.typing():
+                await ctx.channel.purge(limit=len(messages_to_delete), check=lambda m: m.id in ids,
+                                        bulk=False)
+                await ctx.send(f"Deleted {len(messages_to_delete)} message(s)")
+    except discord.Forbidden:
+        await ctx.send("Architus does not have permission to remove messages in this server")
+    except discord.HTTPException:
+        await ctx.send("Failed to reach discord serverrs. Try again in a bit")
+    except Exception:
+        await ctx.send("Something went wrong. :(")
+
+
+@purge.command()
+async def time(ctx, time_window):
+    """
+    Purge a channel of a user's messages
+
+    Usage: {prefix}purge time {XXm|XXs}
+
+    Deletes all messages in the channel in the past number of
+    minutes or seconds.
+
+    NOTE: If the original message is deleted before the bot deletes it, all messages
+    from the target message's author in the channel will be deleted depending on the
+    timing of when the original message was deleted.
+    """
+    # Generally considered bad practice to use the utcnow datetime function.
+    # However, the discord api specifically requires a timezone niave datetime
+    # that represents the relevant time in the UTC timezone. This is exactly
+    # what utcnow gives us so that's what we'll use.
+    # See: https://discordpy.readthedocs.io/en/latest/api.html?highlight=channel#discord.TextChannel.history
+    now = datetime.utcnow()
+    try:
+        if time_window[2] == 'm':
+            mins = int(time_window[0:2])
+            diff = timedelta(minutes=mins)
+        elif time_window[2] == 's':
+            secs = int(time_window[0:2])
+            diff = timedelta(seconds=secs)
+    except ValueError:
+        await ctx.send("Time value formatted improperly")
+        return
+
+    earliest = now - diff
+
+    settings = ctx.bot.settings[ctx.guild]
+    if ctx.author.id not in settings.admins_ids:
+        await ctx.send("You do not have permissions to purge messaages")
+        return
+
+    try:
+        messages_to_delete = await ctx.channel.history(limit=500, after=earliest).flatten()
+    except discord.Forbidden:
+        await ctx.send("Architus does not have permission to read message history")
+        return
+    except discord.HTTPException:
+        await ctx.send("Failed to reach discord servers. Try again in a bit")
+        return
+    except Exception:
+        await ctx.send("Something went wrong. :(")
+        return
+
+    try:
+        if len(messages_to_delete) <= 100:
+            async with ctx.channel.typing():
+                await ctx.channel.delete_messages(messages_to_delete)
+                await ctx.send(f"Deleted {len(messages_to_delete)} message(s)")
+        else:
+            ids = list(map(lambda m: m.id, messages_to_delete))
+            async with ctx.channel.typing():
+                await ctx.channel.purge(limit=len(messages_to_delete), check=lambda m: m.id in ids,
+                                        bulk=False)
+                await ctx.send(f"Deleted {len(messages_to_delete)} message(s)")
+    except discord.Forbidden:
+        await ctx.send("Architus does not have permission to remove messages "
+                       "in this server.")
+        return
+    except discord.HTTPException:
+        await ctx.send("Failed to reach discord servers. Try again in a bit")
+        return
+    except Exception:
+        await ctx.send("Something went wrong. :(")
+        return
 
 
 def setup(bot):

--- a/shard/src/ext/purge_command.py
+++ b/shard/src/ext/purge_command.py
@@ -1,10 +1,14 @@
 import discord
 from discord.ext import commands
+from discord.utils import snowflake_time
 
 import re
 from datetime import datetime, timedelta
 
 TIME_REGEX = re.compile(r"(\d+)([m|s])")
+
+# How far into the message history to search for messages to delete
+MESSAGE_LIMIT = 10000
 
 
 @commands.group()
@@ -30,10 +34,11 @@ async def purge(ctx):
     from the target message's author in the channel will be deleted depending on the
     timing of when the original message was deleted.
     '''
-    # Both subcommands will attempt to use the more efficient channel.delete_messages method
-    # when possible. This operation is only valid when attempting to delete 100
-    # or fewer messages. When this is not possible, the channel.purge method will
-    # be used instead.
+    settings = ctx.bot.settings[ctx.guild]
+    if ctx.author.id not in settings.admins_ids:
+        await ctx.send("You do not have permissions to purge messaages")
+        return
+
     if ctx.invoked_subcommand is None:
         await ctx.send("Need to use command with id or time parameter")
         return
@@ -57,9 +62,11 @@ async def id(ctx, mid, inclusive=False):
     when this command is run, then all of that user's messages may not get
     deleted.
 
-    NOTE: If the original message is deleted before the bot deletes it, all messages
-    from the target message's author in the channel will be deleted depending on the
-    timing of when the original message was deleted.
+    NOTE: If the original message is deleted before the bot deletes it and after
+    Architus has already started to go through the message history, all messages
+    from the target message's author (up to 10,000) in the channel will be deleted.
+    This race condition should have no effect on the command's behavior if
+    all messages are going to be deleted.
     """
     message_id = None
     try:
@@ -68,17 +75,14 @@ async def id(ctx, mid, inclusive=False):
         await ctx.send("Message ID has an invalid format")
         return
 
-    settings = ctx.bot.settings[ctx.guild]
-    if ctx.author.id not in settings.admins_ids:
-        await ctx.send("You do not have permissions to purge messaages")
-        return
-
     try:
         original_message = await ctx.channel.fetch_message(message_id)
     except discord.NotFound:
-        await ctx.send("Original message has already been deleted. "
-                       "Try again with different message.")
-        return
+        if not inclusive:
+            await ctx.send("Message was already deleted and inclusive mod is not set")
+            return
+        sent_time = snowflake_time(message_id)
+        original_message = None
     except discord.Forbidden:
         await ctx.send("Architus does not have permission to read message history")
         return
@@ -90,27 +94,24 @@ async def id(ctx, mid, inclusive=False):
         return
 
     messages_to_delete = []
-    async for m in ctx.channel.history(limit=500):
+    args = dict()
+    if original_message is None:
+        args['after'] = sent_time
+    async for m in ctx.channel.history(limit=MESSAGE_LIMIT, **args):
         if inclusive or m.author == original_message.author:
             messages_to_delete.append(m)
-        if m.id == original_message.id:
+        if original_message is not None and m.id == original_message.id:
             break
 
     try:
-        if len(messages_to_delete) <= 100:
-            async with ctx.channel.typing():
-                await ctx.channel.delete_messages(messages_to_delete)
-                await ctx.send(f"Deleted {len(messages_to_delete)} message(s)")
-        else:
-            ids = list(map(lambda m: m.id, messages_to_delete))
-            async with ctx.channel.typing():
-                deleted = await ctx.channel.purge(limit=len(messages_to_delete), check=lambda m: m.id in ids,
-                                                  bulk=False)
-                await ctx.send(f"Deleted {len(deleted)} message(s)")
+        async with ctx.channel.typing():
+            for i in range(0, len(messages_to_delete), 100):
+                await ctx.channel.delete_messages(messages_to_delete[i:i + 100])
+            await ctx.send(f"Deleted {len(messages_to_delete)} message(s)")
     except discord.Forbidden:
         await ctx.send("Architus does not have permission to remove messages in this server")
     except discord.HTTPException:
-        await ctx.send("Failed to reach discord serverrs. Try again in a bit")
+        await ctx.send("Failed to reach discord servers. Try again in a bit")
     except Exception:
         await ctx.send("Something went wrong. :(")
 
@@ -149,13 +150,8 @@ async def time(ctx, time_window):
 
     earliest = now - diff
 
-    settings = ctx.bot.settings[ctx.guild]
-    if ctx.author.id not in settings.admins_ids:
-        await ctx.send("You do not have permissions to purge messaages")
-        return
-
     try:
-        messages_to_delete = await ctx.channel.history(limit=500, after=earliest).flatten()
+        messages_to_delete = await ctx.channel.history(limit=MESSAGE_LIMIT, after=earliest).flatten()
     except discord.Forbidden:
         await ctx.send("Architus does not have permission to read message history")
         return
@@ -167,16 +163,10 @@ async def time(ctx, time_window):
         return
 
     try:
-        if len(messages_to_delete) <= 100:
-            async with ctx.channel.typing():
-                await ctx.channel.delete_messages(messages_to_delete)
-                await ctx.send(f"Deleted {len(messages_to_delete)} message(s)")
-        else:
-            ids = list(map(lambda m: m.id, messages_to_delete))
-            async with ctx.channel.typing():
-                deleted = await ctx.channel.purge(limit=len(messages_to_delete), check=lambda m: m.id in ids,
-                                                  bulk=False)
-                await ctx.send(f"Deleted {len(deleted)} message(s)")
+        async with ctx.channel.typing():
+            for i in rane(0, len(messages_to_delete), 100):
+                await ctx.channel.delete_messages(messages_to_delete[i:i + 100])
+            await ctx.send(f"Deleted {len(messages_to_delete)} message(s)")
     except discord.Forbidden:
         await ctx.send("Architus does not have permission to remove messages "
                        "in this server.")

--- a/shard/src/ext/purge_command.py
+++ b/shard/src/ext/purge_command.py
@@ -1,6 +1,5 @@
 import discord
 from discord.ext import commands
-from contextlib import suppress
 
 import re
 from datetime import datetime, timedelta
@@ -106,7 +105,7 @@ async def id(ctx, mid, inclusive=False):
             ids = list(map(lambda m: m.id, messages_to_delete))
             async with ctx.channel.typing():
                 deleted = await ctx.channel.purge(limit=len(messages_to_delete), check=lambda m: m.id in ids,
-                                        bulk=False)
+                                                  bulk=False)
                 await ctx.send(f"Deleted {len(deleted)} message(s)")
     except discord.Forbidden:
         await ctx.send("Architus does not have permission to remove messages in this server")
@@ -176,7 +175,7 @@ async def time(ctx, time_window):
             ids = list(map(lambda m: m.id, messages_to_delete))
             async with ctx.channel.typing():
                 deleted = await ctx.channel.purge(limit=len(messages_to_delete), check=lambda m: m.id in ids,
-                                        bulk=False)
+                                                  bulk=False)
                 await ctx.send(f"Deleted {len(deleted)} message(s)")
     except discord.Forbidden:
         await ctx.send("Architus does not have permission to remove messages "


### PR DESCRIPTION
## Description
Improves the functionality and usability of the purge command.

The purge command is split up into two subcommands, id and time, which will purge messages based on a message id or time respectively.

For the id subcommand an admin could run a command like `!purge id 1234567890 [true]`. The number would be a message id of a user's message for which the bot will delete all of the user's messages in that channel from that message onwards. If the optional `true` parameter is passed, then the purged messages will include all users and not just the user who authored the message with the passed id.

The time subcommand will purge all messages in a channel sent in some user specified amount of time. For example, the command `!purge time 20m` will purge all messages in the channel that were sent in the past 20 minutes. The time subcommand allows for time parameters of the type `XXm` or `XXs` which represent some amount of minutes or seconds respectively.

After Architus finishes purging messages, it will send a message to the channel saying how many messages were purged.

This PR closes #21 

## Checklist

- [x] [Linked PR to corresponding issue in this repo](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
- [x] Manually tested locally
- [x] [relevant issue](https://github.com/architus/docs.archit.us/issues/14)
