### PR TITLE
Change Default Latex Rendering Options

### DIFF
--- a/shard/res/generate/template.tex
+++ b/shard/res/generate/template.tex
@@ -1,5 +1,10 @@
-\documentclass[border={4pt 4pt 4pt 4pt},preview]{standalone}
+\documentclass{article}
 \usepackage{mathrsfs,amsmath}
+\usepackage[dvipsnames]{xcolor}
+\pagecolor{Black}
+\color{White}
+\pagenumbering{gobble}
 \begin{document}
+\color{white}
 $my_text
 \end{document}

--- a/shard/src/ext/latex_cog.py
+++ b/shard/src/ext/latex_cog.py
@@ -94,7 +94,8 @@ class Latexify(commands.Cog, name="Latex Compiler"):
                 await ctx.send(embed=embed)
                 return
 
-            convert = await create_subprocess_exec('dvipng', '-T', 'tight', '-D', '300', 'out.dvi',
+            convert = await create_subprocess_exec('dvipng', '-T', 'tight', '-Q', '16', '-D', '900',
+                                                   '-bg', 'transparent', 'out.dvi',
                                                    cwd=work_dir,
                                                    stdout=DEVNULL,
                                                    stderr=DEVNULL,


### PR DESCRIPTION
## Description

Changes the default latex rendering options to be more aesthetically pleasing. The default latex rendering options are to use a white text and transparent background.

## Checklist

- [x] [Implements #65 ](https://github.com/architus/architus/issues/65)
- [x] Manually tested locally
- [x] [Docs Issue](https://github.com/architus/docs.archit.us/issues/22)
