### PR TITLE
Create batched feature check; use DB connection pooling

### DIFF
--- a/feature-gate/Cargo.toml
+++ b/feature-gate/Cargo.toml
@@ -18,10 +18,11 @@ prost = "0.6"
 tokio = { version = "0.2", features = ["macros"] }
 log = "0.4"
 simple_logger = "1.6"
+r2d2 = "0.8"
 
 [dependencies.diesel]
 version = "1.4"
-features = ["postgres"]
+features = ["postgres", "r2d2"]
 
 [build-dependencies]
 tonic-build = "0.2"

--- a/feature-gate/src/bin/feature-gate.rs
+++ b/feature-gate/src/bin/feature-gate.rs
@@ -10,16 +10,16 @@
 #![deny(clippy::all)]
 
 use db::*;
+use diesel::r2d2::ConnectionManager;
 use diesel::PgConnection;
 use log::{info, warn};
+use r2d2::PooledConnection;
 use std::env;
 use tokio::sync::mpsc;
 use tonic::{transport::Server, Request, Response, Status};
 
-use diesel::r2d2::ConnectionManager;
 use feature_gate::feature_gate_server::{FeatureGate, FeatureGateServer};
 use feature_gate::*;
-use r2d2::PooledConnection;
 
 type RpcResponse<T> = Result<Response<T>, Status>;
 

--- a/feature-gate/src/bin/feature-gate.rs
+++ b/feature-gate/src/bin/feature-gate.rs
@@ -27,9 +27,8 @@ pub mod feature_gate {
     include!("../../grpc/featuregate.rs");
 }
 
-/// Structure for handling all of the gRPC requests. Just holds
-/// the address of the postgres database so that it can be used
-/// to connect to the database for each RPC request.
+/// Structure for handling all of the gRPC requests.
+/// Holds a connection pool that can issue RAII connection handles
 pub struct Gate {
     connection_pool: r2d2::Pool<ConnectionManager<PgConnection>>,
 }

--- a/feature-gate/src/lib.rs
+++ b/feature-gate/src/lib.rs
@@ -164,7 +164,7 @@ pub fn check_guild_feature(conn: &PgConnection, guild_id: i64, feature: &str) ->
 ///
 /// First gets the feature id and then checks to see if each of the guild id-feature id
 /// pairs can be found in the guild feature database.
-/// Returns a list of booleans in the same order as the input guild_ids list
+/// Returns a list of booleans in the same order as the input `guild_ids` list
 /// where each element corresponds to whether the corresponding guild has the feature.
 ///
 /// # Arguments
@@ -177,7 +177,7 @@ pub fn check_guild_feature(conn: &PgConnection, guild_id: i64, feature: &str) ->
 /// * `DatabaseError::Query` - The query to the database failed
 pub fn batch_check_guild_feature(
     conn: &PgConnection,
-    guild_ids: &Vec<i64>,
+    guild_ids: &[i64],
     feature: &str,
 ) -> DbResult<Vec<bool>> {
     let feature_id = get_feature_id(conn, feature)?;

--- a/feature-gate/src/lib.rs
+++ b/feature-gate/src/lib.rs
@@ -12,8 +12,10 @@ pub mod schema;
 #[macro_use]
 extern crate diesel;
 
+use diesel::pg::expression::dsl::any;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
+use std::collections::HashSet;
 use thiserror::Error;
 
 /// Simple custom error type for letting the library user know what went
@@ -153,6 +155,54 @@ pub fn check_guild_feature(conn: &PgConnection, guild_id: i64, feature: &str) ->
             } else {
                 Ok(true)
             }
+        }
+        Err(_) => Err(DatabaseError::Query),
+    }
+}
+
+/// Checks to see if a list of guilds has the associated feature.
+///
+/// First gets the feature id and then checks to see if each of the guild id-feature id
+/// pairs can be found in the guild feature database.
+/// Returns a list of booleans in the same order as the input guild_ids list
+/// where each element corresponds to whether the corresponding guild has the feature.
+///
+/// # Arguments
+/// * `conn` - Database connection
+/// * `guild_ids` - List of Guild IDs to check
+/// * `feature` - Name of feature to check on guild
+///
+/// # Errors
+/// * `DatabaseError::UnknownFeature` - Feature is not found in the database
+/// * `DatabaseError::Query` - The query to the database failed
+pub fn batch_check_guild_feature(
+    conn: &PgConnection,
+    guild_ids: &Vec<i64>,
+    feature: &str,
+) -> DbResult<Vec<bool>> {
+    let feature_id = get_feature_id(conn, feature)?;
+
+    let result = schema::tb_guild_features::table
+        .filter(schema::tb_guild_features::feature_id.eq(feature_id))
+        // Note: uses PG-specific feature
+        .filter(schema::tb_guild_features::guild_id.eq(any(guild_ids)))
+        .load::<(i64, i32)>(conn);
+
+    match result {
+        Ok(v) => {
+            // Create set of guilds with the feature enabled
+            let mut with_feature_set = HashSet::<i64>::with_capacity(v.len());
+            for (guild_id, _) in v {
+                with_feature_set.insert(guild_id);
+            }
+
+            // Create an ordered result
+            let mut results = Vec::with_capacity(guild_ids.len());
+            for guild_id in guild_ids {
+                results.push(with_feature_set.contains(guild_id));
+            }
+
+            Ok(results)
         }
         Err(_) => Err(DatabaseError::Query),
     }

--- a/lib/ipc/proto/feature-gate.proto
+++ b/lib/ipc/proto/feature-gate.proto
@@ -7,6 +7,8 @@ service FeatureGate {
     rpc AddGuildFeature(FeatureAddition) returns (AddResult);
     rpc RemoveGuildFeature(FeatureRemoval) returns (RemoveResult);
     rpc CheckGuildFeature(GuildFeature) returns (FeatureResult);
+    // The number of supported guilds to check at once is at least 256, but may be more.
+    rpc BatchCheckGuildFeatures(BatchCheck) returns (BatchCheckResult);
     rpc GetFeatures(FeatureList) returns (stream Feature);
     rpc GetGuildFeatures(Guild) returns (stream Feature);
 }
@@ -35,6 +37,11 @@ message GuildFeature {
     fixed64 guild_id = 2;
 }
 
+message BatchCheck {
+  string feature_name = 1;
+  repeated fixed64 guild_ids = 2;
+}
+
 message Guild {
     fixed64 guild_id = 1;
 }
@@ -60,4 +67,8 @@ message RemoveResult {
 
 message FeatureResult {
     bool has_feature = 1;
+}
+
+message BatchCheckResult {
+  repeated bool has_feature = 1;
 }


### PR DESCRIPTION
Creates a new RPC method in the feature-gate service, "batch_check_guild_feature" that checks for a single feature in a list (<256) of guilds and returns a list of booleans all at once. This RPC method is going to be used in the logs feature to track guilds that have indexing enabled.

Additionally, this PR adds connection pooling to the feature-gate service via `r2d2`