### PR TITLE
Prevent webcomic command from being abused for mentions

### DIFF
--- a/shard/src/ext/webcomic_command.py
+++ b/shard/src/ext/webcomic_command.py
@@ -2,7 +2,7 @@
 # sent directly to your discord channel.
 
 from discord.ext import commands
-from discord import Embed
+from discord import Embed, AllowedMentions
 from bs4 import BeautifulSoup as soup
 import aiohttp
 from src.utils import doc_url
@@ -32,11 +32,8 @@ async def webcomic(ctx, comic='list'):
 
     # Send an error message if invalid comic request
     if comic.lower() not in comics:
-        # TODO: Used allowed mentions parameter when discord.py finally releases 1.4.0a
-        if '@' in comic:
-            await ctx.channel.send("Architus does not support that webcomic")
-        else:
-            await ctx.channel.send(f"Architus does not support the {comic} webcomic")
+        await ctx.channel.send(f"Architus does not support the {comic} webcomic",
+                               allowed_mentions=AllowedMentions.none())
         return
 
     # Send an XKCD embed to the channel


### PR DESCRIPTION
## Description

Update the webcomic command to use new discord.py feature that prevents it from being abused for pining users, roles, etc.

## Checklist

- [X] [Linked PR to corresponding issue in this repo](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
- [X] Manually tested locally
- [X] Additional issue created in [docs repo](https://github.com/architus/docs.archit.us/issues) (if necessary)
