### PR TITLE
Fix syntax error in sandbox's prod k8s manifest

### DIFF
--- a/sandbox/kube/prod/sandbox.yaml
+++ b/sandbox/kube/prod/sandbox.yaml
@@ -20,22 +20,19 @@ spec:
             limits:
               memory: "1Gi"
               cpu: "1"
-          envFrom:
-          - secretRef:
-              name: architus-secret
+          env:
+          - name: HTTP_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: sandbox-config
+                key: HTTP_PROXY
+          - name: HTTPS_PROXY
+            valueFrom:
+              configMapKeyRef:
+                name: sandbox-config
+                key: HTTPS_PROXY
       imagePullSecrets:
         - name: regcred
-      env:
-        - name: HTTP_PROXY
-          valueFrom:
-            configMapKeyRef:
-              name: sandbox-config
-              key: HTTP_PROXY
-        - name: HTTPS_PROXY
-          valueFrom:
-            configMapKeyRef:
-              name: sandbox-config
-              key: HTTPS_PROXY
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Description

This PR fixes a syntax error in the sandbox service's production Kubernetes manifest. This is because the `env` key was in the pod spec and not in a container. This PR also removes mounting `archtitus-secret` in the container, which shouldn't be there.

### Testing

The updated manifest is correct:

```
$ kubectl apply --validate=true --dry-run=client --filename=sandbox/kube/prod/sandbox.yaml
deployment.apps/sandbox configured (dry run)
service/sandbox configured (dry run)
```

## Checklist

- [X] Manually tested locally
