### PR TITLE
Fix feature-gate production build to include config-backoff-rs

### DIFF
--- a/feature-gate/Dockerfile
+++ b/feature-gate/Dockerfile
@@ -1,11 +1,13 @@
 ARG REPO_ROOT=/opt/architus
 ARG SERVICE=feature-gate
+ARG CONFIG_BACKOFF_LIB=lib/config-backoff-rs
 ARG PROTO=lib/ipc/proto
 
 # Build service
 FROM rust:1.50 as builder
 ARG REPO_ROOT
 ARG SERVICE
+ARG CONFIG_BACKOFF_LIB
 ARG PROTO
 RUN rustup component add rustfmt
 # Copy feature-gate service itself
@@ -14,6 +16,10 @@ COPY $SERVICE/src src
 COPY $SERVICE/Cargo.lock .
 COPY $SERVICE/Cargo.toml .
 COPY $SERVICE/build.rs .
+# Copy shared config backoff library
+WORKDIR $REPO_ROOT/$CONFIG_BACKOFF_LIB
+COPY $CONFIG_BACKOFF_LIB/src src
+COPY $CONFIG_BACKOFF_LIB/Cargo.toml .
 # Copy protobuf definitions
 WORKDIR $REPO_ROOT/$PROTO
 COPY $PROTO/feature-gate.proto .


### PR DESCRIPTION
## Description

Includes config-backoff-rs in the feature-gate production build (`feature-gate/Dockerfile`).
