### PR TITLE
Bump RabbitMQ version, use better init.sh script that avoids race condition

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -76,7 +76,7 @@ if 'sandbox' in enabled:
 if 'rabbit' in enabled:
     docker_build('rabbit-image', '.', dockerfile='rabbitmq/Dockerfile', ignore=["*", "!rabbitmq/*", "!lib/**"])
     k8s_yaml('rabbitmq/kube/dev/rabbit.yaml')
-    k8s_resource('rabbit', port_forwards=8090)
+    k8s_resource('rabbit', port_forwards=[8090, 15672])
 
 if 'dbmanager' in enabled:
     docker_build('dbmanager-image', 'dbmanager', dockerfile='dbmanager/Dockerfile')

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -1,9 +1,9 @@
-FROM rabbitmq:3.7.17-management-alpine
+FROM rabbitmq:3.9.7-management-alpine
 
 ENV RABBITMQ_USER hello
 ENV RABBITMQ_PASSWORD hello
 
-ADD rabbitmq/init.sh /init.sh
+COPY rabbitmq/init.sh /init.sh
 EXPOSE 15672
 
 # Define default command

--- a/rabbitmq/init.sh
+++ b/rabbitmq/init.sh
@@ -1,17 +1,54 @@
 #!/bin/sh
 
-# Create Rabbitmq user
-( \
-echo "*** Starting RabbitMQ server and waiting to configure. ***" ; \
-sleep 12 ; \
-echo "*** Starting to configure RabbitMQ server. ***" ; \
-rabbitmqctl add_user $RABBITMQ_USER $RABBITMQ_PASSWORD 2>/dev/null ; \
-rabbitmqctl set_user_tags $RABBITMQ_USER administrator ; \
-rabbitmqctl set_permissions -p / $RABBITMQ_USER  ".*" ".*" ".*" ; \
-echo "*** User '$RABBITMQ_USER' with password '$RABBITMQ_PASSWORD' completed. ***" ; \
-echo "*** Log in the WebUI at port 15672 (example: http:/localhost:15672) ***") &
+log() {
+    # Logs a message using an easily grep-able format
+    # Usage:
+    # log [message]
+
+    echo >&2 "*** init.sh: ${1-} ***"
+}
+
+create_user() {
+    # Continuously creates Rabbitmq user until it succeeds
+    # Usage:
+    # create_user
+
+    initial_delay="5"
+    backoff="5"
+
+    sleep "$initial_delay"
+    log "Starting to configure RabbitMQ server."
+    until try_create_user "$RABBITMQ_USER" "$RABBITMQ_PASSWORD"
+    do
+        log "Creating user failed; waiting $backoff seconds to try again."
+        sleep 5
+    done
+    log "User '$RABBITMQ_USER' with password '$RABBITMQ_PASSWORD' completed."
+    log "Log in the WebUI at port 15672 (example: http:/localhost:15672)"
+}
+
+try_create_user() {
+    # Tries to create the RabbitMQ user once.
+    # If successful, returns a zero exit code.
+    # Otherwise, it should be retried.
+    # Usage:
+    # try_create_user [user] [password]
+
+    user="$1"
+    password="$2"
+    # Use `&&\` at the end of each command
+    # to make the function's return code non-zero if any of them fail,
+    # and also for them to short-circuit
+    # (i.e. if an earlier one fails,
+    # the function returns early without execuitng the later ones)
+    rabbitmqctl await_startup >/dev/null 2>&1 &&\
+    rabbitmqctl add_user "$user" "$password" 2>/dev/null &&\
+    rabbitmqctl set_user_tags "$user" administrator &&\
+    rabbitmqctl set_permissions -p / "$password" ".*" ".*" ".*"
+}
 
 # $@ is used to pass arguments to the rabbitmq-server command.
 # For example if you use it like this: docker run -d rabbitmq arg1 arg2,
 # it will be as you run in the container rabbitmq-server arg1 arg2
-rabbitmq-server $@
+log "Starting RabbitMQ server and waiting to configure."
+(create_user & rabbitmq-server "$@")

--- a/rabbitmq/kube/dev/rabbit.yaml
+++ b/rabbitmq/kube/dev/rabbit.yaml
@@ -26,13 +26,16 @@ metadata:
   name: rabbit
   namespace: default
 spec:
-  type: ClusterIP
+  type: NodePort
   selector:
     app: rabbit
   ports:
   - name: main
     port: 5672
     targetPort: 5672
+  - name: web
+    port: 15672
+    targetPort: 15672
   - name: admin
     port: 8090
     targetPort: 8090


### PR DESCRIPTION
## Description

This PR contains a few minor changes to the RabbitMQ service configuration:
- bumps its version to the latest stable version (3.9.7)
- exposes the web port (15672) during local development for debugging/monitoring
- Use a re-written `init.sh` script that properly retries creating the user in case it fails at first, preventing a race condition that was previously present where the script would only succeed if RabbitMQ came up and was ready to accept connections before the end of the 12-second timer.
